### PR TITLE
Adds setFieldData Utility

### DIFF
--- a/src/client.model.js
+++ b/src/client.model.js
@@ -11,7 +11,8 @@ const {
   isJson,
   stringify,
   sanitizeParameters,
-  parseScriptResult
+  parseScriptResult,
+  setFieldData
 } = require('./utilities');
 
 /**
@@ -382,9 +383,7 @@ class Client extends Document {
                 'script.presort.param',
                 'request'
               ]),
-              {
-                fieldData: this.data.incoming(stringify(data))
-              }
+              this.data.incoming(setFieldData(data))
             )
           })
         )
@@ -436,9 +435,7 @@ class Client extends Document {
                 'script.presort.param',
                 'request'
               ]),
-              {
-                fieldData: this.data.incoming(stringify(data))
-              }
+              this.data.incoming(setFieldData(data))
             )
           })
         )

--- a/src/client.model.js
+++ b/src/client.model.js
@@ -12,7 +12,7 @@ const {
   stringify,
   sanitizeParameters,
   parseScriptResult,
-  setFieldData
+  setData
 } = require('./utilities');
 
 /**
@@ -383,7 +383,7 @@ class Client extends Document {
                 'script.presort.param',
                 'request'
               ]),
-              this.data.incoming(setFieldData(data))
+              this.data.incoming(setData(data))
             )
           })
         )
@@ -435,7 +435,7 @@ class Client extends Document {
                 'script.presort.param',
                 'request'
               ]),
-              this.data.incoming(setFieldData(data))
+              this.data.incoming(setData(data))
             )
           })
         )

--- a/src/utilities/conversion.utilities.js
+++ b/src/utilities/conversion.utilities.js
@@ -41,7 +41,7 @@ const toArray = data => (Array.isArray(data) ? data : [data]);
  * @method isJson
  * @public
  * @description The isJson method uses the a try / catch to parse incoming data safely as json.
- * This method will return tru if it is able to cast the incoming data as json.
+ * This method will return true if it is able to cast the incoming data as json.
  * @param  {Any} data The data to be evaluated as json.
  * @return {Boolean}      A boolean result depending on if the data passed to it is valid JSON
  */

--- a/src/utilities/filemaker.utilities.js
+++ b/src/utilities/filemaker.utilities.js
@@ -189,9 +189,9 @@ const namespace = data =>
   );
 
 /**
- * @method setFieldData
+ * @method setData
  * @public
- * @description The setFieldData method checks the incoming data for a fieldData property.
+ * @description The setData method checks the incoming data for a fieldData property.
  * the fieldData property is not found it will create the property and add all properties
  * except portalData to the fieldData property.
  * @param  {Object} data An object to use when creating or editing records.
@@ -208,8 +208,8 @@ const setFieldData = data =>
     },
     _.has(data, 'portalData')
       ? {
-          portalData: _.mapValues(data.portalData, datum =>
-            _.map(datum, object => stringify(object))
+          portalData: _.mapValues(data.portalData, data =>
+            _.map(data, object => stringify(object))
           )
         }
       : {}
@@ -221,5 +221,5 @@ module.exports = {
   namespace,
   parseScriptResult,
   sanitizeParameters,
-  setFieldData
+  setData
 };

--- a/src/utilities/filemaker.utilities.js
+++ b/src/utilities/filemaker.utilities.js
@@ -198,7 +198,7 @@ const namespace = data =>
  * @return {Object}      A modified object containing with the fieldData property
  */
 
-const setFieldData = data =>
+const setData = data =>
   Object.assign(
     {},
     {

--- a/src/utilities/filemaker.utilities.js
+++ b/src/utilities/filemaker.utilities.js
@@ -188,10 +188,38 @@ const namespace = data =>
       _.includes(['limit', 'offset', 'sort'], key) ? `_${key}` : key
   );
 
+/**
+ * @method setFieldData
+ * @public
+ * @description The setFieldData method checks the incoming data for a fieldData property.
+ * the fieldData property is not found it will create the property and add all properties
+ * except portalData to the fieldData property.
+ * @param  {Object} data An object to use when creating or editing records.
+ * @return {Object}      A modified object containing with the fieldData property
+ */
+
+const setFieldData = data =>
+  Object.assign(
+    {},
+    {
+      fieldData: !_.has(data, 'fieldData')
+        ? stringify(_.omit(data, 'portalData'))
+        : stringify(data.fieldData)
+    },
+    _.has(data, 'portalData')
+      ? {
+          portalData: _.mapValues(data.portalData, datum =>
+            _.map(datum, object => stringify(object))
+          )
+        }
+      : {}
+  );
+
 module.exports = {
   fieldData,
   recordId,
   namespace,
   parseScriptResult,
-  sanitizeParameters
+  sanitizeParameters,
+  setFieldData
 };

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -6,7 +6,7 @@ const {
   namespace,
   parseScriptResult,
   sanitizeParameters,
-  setFieldData
+  setData
 } = require('./filemaker.utilities');
 
 const { omit, stringify, toArray, isJson } = require('./conversion.utilities');
@@ -18,7 +18,7 @@ module.exports = {
   omit,
   recordId,
   stringify,
-  setFieldData,
+  setData,
   toArray,
   isJson,
   namespace,

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -5,7 +5,8 @@ const {
   recordId,
   namespace,
   parseScriptResult,
-  sanitizeParameters
+  sanitizeParameters,
+  setFieldData
 } = require('./filemaker.utilities');
 
 const { omit, stringify, toArray, isJson } = require('./conversion.utilities');
@@ -17,6 +18,7 @@ module.exports = {
   omit,
   recordId,
   stringify,
+  setFieldData,
   toArray,
   isJson,
   namespace,

--- a/tests/create.test.js
+++ b/tests/create.test.js
@@ -50,8 +50,43 @@ describe('Create Capabilities', () => {
       .catch(error => done());
   });
 
-  it('should create FileMaker records.', () => {
+  it('should create FileMaker records without fieldData', () => {
     return expect(client.create(process.env.LAYOUT, { name: 'Han Solo' }))
+      .to.eventually.be.a('object')
+      .that.has.all.keys('recordId', 'modId');
+  });
+
+  it('should create FileMaker records using fieldData', () => {
+    return expect(
+      client.create(process.env.LAYOUT, { fieldData: { name: 'Han Solo' } })
+    )
+      .to.eventually.be.a('object')
+      .that.has.all.keys('recordId', 'modId');
+  });
+
+  it('should create FileMaker records with portalData', () => {
+    return expect(
+      client.create(process.env.LAYOUT, {
+        fieldData: { name: 'Han Solo' },
+        portalData: { Vehicles: [{ 'Vehicles::name': 'Millenium Falcon' }] }
+      })
+    )
+      .to.eventually.be.a('object')
+      .that.has.all.keys('recordId', 'modId');
+  });
+
+  it('should allow portalData to be an object or number', () => {
+    return expect(
+      client.create(process.env.LAYOUT, {
+        fieldData: { name: 'Han Solo' },
+        portalData: {
+          Vehicles: [
+            { 'Vehicles::name': { name: 'Millenium Falcon -test' } },
+            { 'Vehicles::name': 5 }
+          ]
+        }
+      })
+    )
       .to.eventually.be.a('object')
       .that.has.all.keys('recordId', 'modId');
   });

--- a/tests/edit.test.js
+++ b/tests/edit.test.js
@@ -92,7 +92,7 @@ describe('Edit Capabilities', () => {
           fieldData: { name: 'Han Solo' },
           portalData: {
             Vehicles: [
-              { 'Vehicles::name': { name: 'Millenium Falcon -test' } },
+              { 'Vehicles::name': { name: 'Millenium Falcon' } },
               { 'Vehicles::name': 5 }
             ]
           }

--- a/tests/edit.test.js
+++ b/tests/edit.test.js
@@ -48,11 +48,54 @@ describe('Edit Capabilities', () => {
       .catch(error => done());
   });
 
-  it('should edit FileMaker records.', () => {
+  it('should edit FileMaker records without fieldData', () => {
     client.create(process.env.LAYOUT, { name: 'Obi-Wan' }).then(response =>
       expect(
         client.edit(process.env.LAYOUT, response.recordId, {
           name: 'Luke Skywalker'
+        })
+      )
+        .to.eventually.be.a('object')
+        .that.has.all.keys('modId')
+    );
+  });
+
+  it('should edit FileMaker records using fieldData', () => {
+    client.create(process.env.LAYOUT, { name: 'Obi-Wan' }).then(response =>
+      expect(
+        client.edit(process.env.LAYOUT, response.recordId, {
+          fieldData: { name: 'Luke Skywalker' }
+        })
+      )
+        .to.eventually.be.a('object')
+        .that.has.all.keys('modId')
+    );
+  });
+
+  it('should edit FileMaker records with portalData', () => {
+    client.create(process.env.LAYOUT, { name: 'Obi-Wan' }).then(response =>
+      expect(
+        client.edit(process.env.LAYOUT, response.recordId, {
+          fieldData: { name: 'Han Solo' },
+          portalData: { Vehicles: [{ 'Vehicles::name': 'Millenium Falcon' }] }
+        })
+      )
+        .to.eventually.be.a('object')
+        .that.has.all.keys('modId')
+    );
+  });
+
+  it('should edit FileMaker records with portalData and allow portalData to be an array.', () => {
+    client.create(process.env.LAYOUT, { name: 'Obi-Wan' }).then(response =>
+      expect(
+        client.edit(process.env.LAYOUT, response.recordId, {
+          fieldData: { name: 'Han Solo' },
+          portalData: {
+            Vehicles: [
+              { 'Vehicles::name': { name: 'Millenium Falcon -test' } },
+              { 'Vehicles::name': 5 }
+            ]
+          }
         })
       )
         .to.eventually.be.a('object')


### PR DESCRIPTION
This commit adds a setFieldData Utility function. This function will allow portalData to be set on the client’s create and edit methods.

the setFieldData will stringify objects and numbers in the portalData’s properties.

Signed-off-by: Lui de la Parra <Lui@mutesymphony.com>