### PR TITLE
Session testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A FileMaker Data API client designed to allow easier interaction with a FileMaker database from a web environment.",
   "main": "index.js",
   "scripts": {
-    "test": "nyc _mocha --recursive  ./test/*.test.js --timeout=15000 --exit",
+    "test": "nyc _mocha --recursive  ./test/session.test.js --timeout=40000 --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "report": "nyc report --reporter=html",
     "examples": "node examples/index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A FileMaker Data API client designed to allow easier interaction with a FileMaker database from a web environment.",
   "main": "index.js",
   "scripts": {
-    "test": "nyc _mocha --recursive  ./test/session.test.js --timeout=40000 --exit",
+    "test": "nyc _mocha --recursive  ./test/*.test.js --timeout=40000 --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "report": "nyc report --reporter=html",
     "examples": "node examples/index.js",

--- a/src/models/session.model.js
+++ b/src/models/session.model.js
@@ -43,6 +43,13 @@ class Session extends EmbeddedDocument {
       used: {
         type: String
       },
+      /* A string containing the request created when the token is in use..
+       * @member Session#request
+       * @type String
+       */
+      request: {
+        type: String
+      },
       /* A boolean set if the current session is in use.
        * @member Session#active
        * @type Boolean
@@ -95,12 +102,25 @@ class Session extends EmbeddedDocument {
    * @method extend
    * @memberof Session
    * @public
-   * @description This method extends a Data API session and sets it to inactive.
+   * @description This method extends a Data API session.
    * @see  {@link Agent#handleResponse}
    */
   extend() {
     this.active = false;
     this.expires = moment().add(15, 'minutes').format();
+  }
+
+  /**
+   * @method  deactivate
+   * @memberOf Sessions
+   * @public
+   * @description This method sets deactivates a session by setting active to false.
+   * @see  {@link Agent#handleResponse}
+   * @see  {@link Agent#handleError}
+   */
+  deactivate() {
+    this.request = "";
+    this.active = false;
   }
 }
 

--- a/test/admin/index.js
+++ b/test/admin/index.js
@@ -30,8 +30,15 @@ const login = () =>
       return response.data.response.token;
     });
 
-const logout = (token = adminToken) => instance
+const logout = (token = adminToken) =>
+  token
+    ? instance
         .delete(`/fmi/admin/api/v2/user/auth/${token}`, {})
+        .then(response => {
+          adminToken = false;
+          return response.data.response.token;
+        })
+    : Promise.resolve();
 
 const remove = ({ id }, token = adminToken) =>
   instance

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -42,6 +42,7 @@ describe('Request Queue Capabilities', () => {
     client = Filemaker.create({
       database: process.env.DATABASE,
       server: process.env.SERVER,
+      concurrency: 25,
       user: process.env.USERNAME,
       password: process.env.PASSWORD
     });

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+/* global describe before after it */
+
+/* eslint-disable */
+
+const assert = require('assert');
+const { expect, should } = require('chai');
+const { admin } = require('./admin');
+
+/* eslint-enable */
+
+const path = require('path');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const environment = require('dotenv');
+const varium = require('varium');
+const { connect } = require('marpat');
+const { Filemaker } = require('../index.js');
+
+const manifestPath = path.join(__dirname, './env.manifest');
+
+chai.use(chaiAsPromised);
+
+describe('Session Capabilities', () => {
+  describe('Session Efficency', () => {
+    let database;
+    let client;
+    const name = 'testing-client';
+
+    before(done => {
+      environment.config({ path: './test/.env' });
+      varium({ manifestPath });
+      connect('nedb://memory')
+        .then(db => {
+          database = db;
+          return database.dropDatabase();
+        })
+        .then(() => {
+          client = Filemaker.create({
+            name,
+            database: process.env.DATABASE,
+            server: process.env.SERVER,
+            user: process.env.USERNAME,
+            concurrency: 25,
+            password: process.env.PASSWORD
+          });
+          return client.save();
+        })
+        .then(client => admin.login())
+        .then(() => admin.sessions.drop({ userName: process.env.USERNAME }))
+        .then(() => setTimeout(() => done(), 15000));
+    });
+
+    after(done => {
+      admin
+        .logout()
+        .then(() => done())
+        .catch(error => done(new Error(error.response.data.messages[0].text)));
+    });
+
+    it('should reuse sessions when they are avalable', () => {
+      const wait = 5000;
+      const repetition = 5;
+      const results = [];
+      const chain = client =>
+        new Promise((resolve, reject) => {
+          const interval = setInterval(() => {
+            client
+              .find(
+                process.env.LAYOUT,
+                { id: '*' },
+                { omit: true, name: 'Darth Vader' }
+              )
+              .then(result => {
+                results.push(results);
+                if (results.length >= repetition) {
+                  clearInterval(interval);
+                  resolve({ client, results });
+                }
+              });
+          }, wait);
+        });
+
+      return expect(
+        Filemaker.findOne({ name })
+          .then(client => chain(client))
+          .then(
+            ({ client, results }) =>
+              new Promise(resolve =>
+                setTimeout(() => resolve({ client, results }), 12000)
+              )
+          )
+          .then(() =>
+            admin.sessions.find({
+              userName: process.env.USERNAME
+            })
+          )
+      )
+        .to.eventually.be.a('array')
+        .to.have.a.lengthOf(1);
+    });
+  });
+
+  describe('Session Concurrency', () => {
+    let database;
+    let client;
+    const name = 'testing-client';
+
+    before(done => {
+      environment.config({ path: './test/.env' });
+      varium({ manifestPath });
+      connect('nedb://memory')
+        .then(db => {
+          database = db;
+          return database.dropDatabase();
+        })
+        .then(() => {
+          client = Filemaker.create({
+            name,
+            database: process.env.DATABASE,
+            server: process.env.SERVER,
+            user: process.env.USERNAME,
+            concurrency: 25,
+            password: process.env.PASSWORD
+          });
+          return client.save();
+        })
+        .then(client => admin.login())
+        .then(() => admin.sessions.drop({ userName: process.env.USERNAME }))
+        .then(() => setTimeout(() => done(), 15000));
+    });
+
+    after(done => {
+      admin
+        .logout()
+        .then(() => done())
+        .catch(error => done(new Error(error.response.data.messages[0].text)));
+    });
+
+    it('should create new sessions to prevent request collisions', () => {
+      const wait = 1000;
+      let current = 0;
+      const repetition = 5;
+      const results = [];
+      const chain = client =>
+        new Promise((resolve, reject) => {
+          const interval = setInterval(() => {
+            current = current + 1;
+            if (current <= repetition) {
+              client
+                .script(process.env.LAYOUT, 'Pause Script', {
+                  pause: 5
+                })
+                .then(result => {
+                  results.push(results);
+                  if (results.length >= repetition) {
+                    resolve({ client, results });
+                  }
+                });
+            } else {
+              clearInterval(interval);
+            }
+          }, wait);
+        });
+
+      return expect(
+        Filemaker.findOne({ name })
+          .then(client => chain(client))
+          .then(
+            ({ client, results }) =>
+              new Promise(resolve =>
+                setTimeout(() => resolve({ client, results }), 12000)
+              )
+          )
+          .then(() =>
+            admin.sessions.find({
+              userName: process.env.USERNAME
+            })
+          )
+      )
+        .to.eventually.be.a('array')
+        .to.have.a.lengthOf(repetition);
+    });
+  });
+});


### PR DESCRIPTION
This PR updates multiple models to solve an issue (#71) where sessions are not reused. This PR modifies multiple models and methods. This commit modifies the agent, connection, and session models.

The agent model's watch method has been updated to iterate through sessions. The agent model will deactivate any session that has an empty request id. The watch method logic has also been updated to ensure it properly waits for an available session. The agent request method has been updated to fix an issue where multiple axios interceptors would be registered for an instance.

The connection model has been revised to remove the ready method and add a confirm and deactivate method. The confirm method will iterate through sessions and deactivate any sessions that are in an unknown state. The deactivate method will target a specific session for deactivation given an authorization header or id.