### PR TITLE
Remove camelCase renaming of field names

### DIFF
--- a/src/services/transform.service.js
+++ b/src/services/transform.service.js
@@ -13,6 +13,7 @@ const _ = require('lodash');
  * @description This function tranforms an object given by turning related tables into objects
  * @param  {Object} object The response recieved from the FileMaker DAPI.
  * @param  {String} parentKey The response recieved from the FileMaker DAPI.
+ * @param  {Object} options Options object to modify how this function performs.
  * @return {Object}      A JSON object containing the selected data from the Data API Response.
  */
 const transformRelatedTables = (object, parentKey) =>
@@ -21,9 +22,9 @@ const transformRelatedTables = (object, parentKey) =>
     (accumulator, value, key) => {
       if (key.includes('::')) {
         const position = key.indexOf('::');
-        const parent = _.camelCase(parentKey);
-        const table = _.camelCase(key.slice(0, position));
-        const field = _.camelCase(key.slice(position + 2));
+        const parent = parentKey;
+        const table = key.slice(0, position);
+        const field = key.slice(position + 2);
         if (
           !Object.prototype.hasOwnProperty.call(accumulator, table) &&
           table !== parent


### PR DESCRIPTION
Propose to remove the automatic camelCasing of field names when going through the transform pipeline.

We ran into issues where field names changed unexpectedly - but only on portal data. Tracked it down to this transformRelatedTables function that transforms the field names to camel case in the process.

I'm not opposed to having camel case as an option, otherwise is comes as an unexpected name transform.

Our application is we are manually mapping field names from FileMaker into our API using a JSON schema. In order to succeed we need to be able to predictably know what the FileMaker field name is so we can map it to our API field name. We ran into this issue only when we began using portals. It seems only the portal field names are being camel cased.

Let me know you thoughts on it and maybe some of the reasoning why you're camel casing in that step.