### PR TITLE
Increases timeout for Session Efficiency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A FileMaker Data API client designed to allow easier interaction with a FileMaker database from a web environment.",
   "main": "index.js",
   "scripts": {
-    "test": "nyc _mocha --recursive  ./test/*.test.js --timeout=40000 --exit",
+    "test": "nyc _mocha --recursive  ./test/*.test.js --timeout=50000 --exit",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "report": "nyc report --reporter=html",
     "examples": "node examples/index.js",


### PR DESCRIPTION
the session efficiency test is routinely taking 38-40 seconds and occasionally exceeding 40 and causing the build to fail. 50s should provide more buffer.